### PR TITLE
Add InterVideo RC-201 protocol

### DIFF
--- a/src/main/resources/IrpProtocols.xml
+++ b/src/main/resources/IrpProtocols.xml
@@ -439,6 +439,10 @@ Note (BM): These two entries was one in the original document; I split it into t
         <irp:documentation>
             <a href="http://www.hifi-remote.com/forums/viewtopic.php?t=14219">See this</a>.</irp:documentation>
     </irp:protocol>
+    <irp:protocol c-name="InterVideoRC201" name="InterVideo RC-201">
+        <irp:irp><![CDATA[{38k,300}<1,-1|1,-3>(10,-5,0:1,F:6,768:10,1,-10m)* [F:0..63]]]></irp:irp>
+        <irp:documentation>Used by a remote marked as <i>InterVideo RC-201</i> that is paired with a USB HID receiver simply marked as <i>RC-201</i>. Exact carrier frequency not known.</irp:documentation>
+    </irp:protocol>
     <irp:protocol c-name="IODATAn" name="IODATAn">
         <irp:parameter name="alt_name">IODATAn-x-y</irp:parameter>
         <!--irp:parameter name="uei-executor">not known.</irp:parameter-->


### PR DESCRIPTION
First, thanks for all your great work on remote control protocols!

This commit adds an InterVideo RC-201 protocol, which is used by an eponymous remote that was
originally paired with a USB HID receiver simply marked as "RC-201" (vid 0x0419 pid 0x0001).
