### PR TITLE
NEC-Shirriff length parameter cannot be more than 32

### DIFF
--- a/src/main/resources/IrpProtocols.xml
+++ b/src/main/resources/IrpProtocols.xml
@@ -1490,7 +1490,7 @@ C3=D:1:2 + #(F&44) + #(D&2)
 
     <irp:protocol name="NEC-Shirriff">
         <irp:irp>
-            <![CDATA[{38.4k,msb,564}<1,-1|1,-3>(16,-8,data:length,1,^108m) [data:0..UINT32_MAX,length:1..64]]]>
+            <![CDATA[{38.4k,msb,564}<1,-1|1,-3>(16,-8,data:length,1,^108m) [data:0..UINT32_MAX,length:1..32]]]>
         </irp:irp>
         <irp:documentation xml:space="preserve">Like <a href="#NEC1">NEC1</a> but without <a href="#repeat">repeat</a>, just one large parameter, and msb bit order, no ending silence, and undetermined payload length.
             This is how NEC protocols are referred to in the Arduino <a href="https://github.com/z3t0/Arduino-IRremote">IRremote</a> project, originated by Ken Shirriff.


### PR DESCRIPTION
When encoding with generated random parameters, the following error can occur:

$ ./irptransmogrifier.sh render -r -n data=2663317484,length=60 NEC-Shirriff
Argument of extent smaller than actual duration

IrpProtocols.xml says the NEC-Shirriff protocol is used by https://github.com/z3t0/Arduino-IRremote project. I've looked at the source code:

 - Current versions cannot send or decode the variable-length format, only 32 bit lengths
 - Old versions could decode signal of up-to 32 bits, they could not deal with any more

Either we remove the NEC-Shirriff protocol or fix it. 

Fixes #226
