### PR TITLE
Ensure that irp with * repeat must have all intro variants empty

### DIFF
--- a/src/main/java/org/harctoolbox/irp/BareIrStream.java
+++ b/src/main/java/org/harctoolbox/irp/BareIrStream.java
@@ -152,12 +152,16 @@ public final class BareIrStream extends IrpObject implements IrStreamItem {
     public boolean hasVariation(boolean recursive, Pass pass) {
         for (IrStreamItem irStreamItem : irStreamItems) {
             if (irStreamItem instanceof Variation)
-                return ((Variation) irStreamItem).hasPart(pass);
+                if (((Variation) irStreamItem).hasPart(pass))
+                    return true;
             if (recursive && irStreamItem instanceof BitspecIrstream)
                 if (((BitspecIrstream) irStreamItem).hasVariation(recursive, pass))
                     return true;
             if (recursive && irStreamItem instanceof BareIrStream)
                 if (((BareIrStream) irStreamItem).hasVariation(recursive, pass))
+                    return true;
+            if (recursive && irStreamItem instanceof IrStream)
+                if (((IrStream) irStreamItem).hasVariation(recursive, pass))
                     return true;
         }
         return false; // give up
@@ -171,6 +175,8 @@ public final class BareIrStream extends IrpObject implements IrStreamItem {
                 return ((BitspecIrstream) irStreamItem).hasVariationWithIntroEqualsRepeat();
             if (irStreamItem instanceof BareIrStream)
                 return ((BareIrStream) irStreamItem).hasVariationWithIntroEqualsRepeat();
+            if (irStreamItem instanceof IrStream)
+                return ((IrStream) irStreamItem).hasVariationWithIntroEqualsRepeat();
         }
         return false; // give up
     }

--- a/src/test/java/org/harctoolbox/irp/ProtocolNGTest.java
+++ b/src/test/java/org/harctoolbox/irp/ProtocolNGTest.java
@@ -1016,6 +1016,46 @@ public class ProtocolNGTest {
         assertEquals(irSignal.toString(true), "Freq=38000Hz[+111,-222,+11,-100][+111,-222,+22,-100][+111,-222,+33,-100]");
     }
 
+    @Test
+    @SuppressWarnings("ResultOfObjectAllocationIgnored")
+    public void testVariantRepeat() throws NameUnassignedException, InvalidNameException, IrpInvalidArgumentException, UnsupportedRepeatException, DomainViolationException, OddSequenceLengthException {
+        try {
+            new Protocol("{}<1,-1|1,-3>([11][22][33],-100)*");
+            fail();
+        } catch (UnsupportedRepeatException ex) {
+            // success!
+        } catch (InvalidNameException | IrpInvalidArgumentException | NameUnassignedException ex) {
+            fail();
+        }
+
+        try {
+            new Protocol("{}<1,-1|1,-3>(100,-10,([11][22][33])2,-100)*");
+            fail();
+        } catch (UnsupportedRepeatException ex) {
+            // success!
+        } catch (InvalidNameException | IrpInvalidArgumentException | NameUnassignedException ex) {
+            fail();
+        }
+
+        try {
+            new Protocol("{}<1,-1|1,-3>(100,-10,([][22][33])2,([11][22][33])2,-100)*");
+            fail();
+        } catch (UnsupportedRepeatException ex) {
+            // success!
+        } catch (InvalidNameException | IrpInvalidArgumentException | NameUnassignedException ex) {
+            fail();
+        }
+
+        try {
+            new Protocol("{}<1,-1|1,-3>(100,-10,[][22][33],[11][22][33],-100)*");
+            fail();
+        } catch (UnsupportedRepeatException ex) {
+            // success!
+        } catch (InvalidNameException | IrpInvalidArgumentException | NameUnassignedException ex) {
+            fail();
+        }
+    }
+
     /**
      * Test of sort method, of class Protocol.
      */


### PR DESCRIPTION
hasVariation() terminates at the first variation and does not recurse down IrStream