### PR TITLE
Bitfields should be limited, else rendering will fail for some inputs

### DIFF
--- a/src/main/java/org/harctoolbox/irp/FiniteBitField.java
+++ b/src/main/java/org/harctoolbox/irp/FiniteBitField.java
@@ -144,7 +144,7 @@ public final class FiniteBitField extends BitField implements IrStreamItem {
 
     public String toBinaryString(NameEngine nameEngine) throws NameUnassignedException {
         String str = Long.toBinaryString(toLong(nameEngine));
-        int wid = (int) width.toLong(nameEngine);
+        int wid = (int) getWidth(nameEngine);
         int len = str.length();
         if (len > wid)
             return str.substring(len - wid);
@@ -157,7 +157,11 @@ public final class FiniteBitField extends BitField implements IrStreamItem {
 
     @Override
     public long getWidth(NameEngine nameEngine) throws NameUnassignedException {
-        return width.toLong(nameEngine);
+        long wid = width.toLong(nameEngine);
+        if (wid > MAXWIDTH) {
+            wid = MAXWIDTH;
+        }
+        return wid;
     }
 
     @Override
@@ -186,7 +190,7 @@ public final class FiniteBitField extends BitField implements IrStreamItem {
 
         String widthString;
         try {
-            widthString = Long.toString(width.toLong(nameEngine));
+            widthString = Long.toString(getWidth(nameEngine));
         } catch (NameUnassignedException ex) {
             widthString = width.toIrpString(10);
         }

--- a/src/test/java/org/harctoolbox/irp/ProtocolNGTest.java
+++ b/src/test/java/org/harctoolbox/irp/ProtocolNGTest.java
@@ -1056,6 +1056,18 @@ public class ProtocolNGTest {
         }
     }
 
+    @Test
+    public void testLargeBitField() throws NameUnassignedException, InvalidNameException, IrpInvalidArgumentException,
+            UnsupportedRepeatException, DomainViolationException, OddSequenceLengthException {
+        // Bitfield Should be limited to 63, else this will run forever until heap is exhausted
+        Protocol protocol = new Protocol("{38.4k,416,msb}<1,-6|1,-12>(1:1000000000)*");
+
+        IrSignal irSignal = protocol.toIrSignal(NameEngine.EMPTY);
+
+        assertEquals(irSignal.toString(true),
+                "Freq=38400Hz[][+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-2496,+416,-4992][]");
+    }
+
     /**
      * Test of sort method, of class Protocol.
      */


### PR DESCRIPTION
If the width is a large number, then rendering this will fail after some when the heap is exhausted:

{38.4k,416,msb}<1,-6|1,-12>(1:1000000000)*