### PR TITLE
Make number parsing consistent

### DIFF
--- a/src/main/java/org/harctoolbox/irp/NumberWithDecimals.java
+++ b/src/main/java/org/harctoolbox/irp/NumberWithDecimals.java
@@ -54,7 +54,7 @@ public final class NumberWithDecimals extends IrpObject implements Floatable {
         Objects.requireNonNull(child);
         data = (child instanceof IrpParser.Float_numberContext)
                 ? FloatNumber.parse((IrpParser.Float_numberContext) child)
-                : Integer.parseInt(child.getText());
+                : Long.parseLong(child.getText());
     }
 
     public NumberWithDecimals(double d) {

--- a/src/test/java/org/harctoolbox/irp/DurationNGTest.java
+++ b/src/test/java/org/harctoolbox/irp/DurationNGTest.java
@@ -71,6 +71,10 @@ public class DurationNGTest {
             result = Duration.newDuration("^A p");
             assertTrue(result instanceof Extent);
             assertEquals(result.toFloat(generalSpec, nameEngine), 3750f, 0.0001);
+
+            result = Duration.newDuration("55555555555");
+            assertTrue(result instanceof Flash);
+            assertEquals(result.toFloat(generalSpec, nameEngine), 11111111111000f, 1e5);
         } catch (IrpInvalidArgumentException | InvalidNameException | NameUnassignedException ex) {
             fail();
         }


### PR DESCRIPTION
Durations are parsed with Integers but other numbers are parsed as longs; this inconsistency makes fuzzy harder.